### PR TITLE
Use 50,000 remediation points

### DIFF
--- a/lib/cc/engine/scalastyle.rb
+++ b/lib/cc/engine/scalastyle.rb
@@ -23,7 +23,7 @@ module CC
                 check_name: lint["source"],
                 description: lint["message"],
                 categories: ["Style"],
-                remediation_points: 500,
+                remediation_points: 50_000,
                 location: {
                   path: path,
                   positions: {


### PR DESCRIPTION
500 is _much_ too low. Spec says 50,000 is appropriate for trivial
issues like missing semicolons, so it seems like an appropriate baseline
here.
